### PR TITLE
Preserve non-ASCII characters in JSON output for better multilingual support

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -552,7 +552,7 @@ def _convert_to_content(
 
     if not isinstance(result, str):
         try:
-            result = json.dumps(pydantic_core.to_jsonable_python(result))
+            result = json.dumps(pydantic_core.to_jsonable_python(result), ensure_ascii=False)
         except Exception:
             result = str(result)
 


### PR DESCRIPTION
This merge request adds the ensure_ascii=False parameter to json.dumps() when serializing content to JSON strings in the FastMCP server. This critical change ensures that non-ASCII characters (such as Chinese, Japanese, Arabic, Cyrillic, etc.) are preserved in their original form rather than being escaped as Unicode sequences.

Comprehension Barriers for LLMs: AI models frequently struggle to properly parse and understand Unicode escape sequences. For example, when Chinese text "你好" is encoded as "\u4f60\u597d", large language models often mistakenly interpret them as code or special instructions.